### PR TITLE
Meta/front to back end connection

### DIFF
--- a/backEnd/src/main/java/genome/DataContainer.java
+++ b/backEnd/src/main/java/genome/DataContainer.java
@@ -16,6 +16,8 @@ public class DataContainer {
     private HashMap<Integer, Node> nodes;
     private HashMap<String, Edge> edges;
     private HashMap<String, Genome> genomes;
+    private double dataWidth;
+    private double dataHeight;
 
     /**
      * Constructer for the datacontainer, starts with empty hashmaps.
@@ -108,4 +110,20 @@ public class DataContainer {
         return nodesByxCoordinate;
     }
 
+	public double getDataWidth() {
+		return this.dataWidth;
+	}
+
+	public double getDataHeight() {
+		return this.dataHeight;
+	}
+
+	public void setDataWidth(double dataWidth) {
+		this.dataWidth = dataWidth;
+	}
+
+	public void setDataHeight(double dataHeight) {
+		this.dataHeight = dataHeight;
+	}
+    
 }

--- a/backEnd/src/main/java/genome/DataContainer.java
+++ b/backEnd/src/main/java/genome/DataContainer.java
@@ -20,7 +20,8 @@ public class DataContainer {
     /**
      * Constructer for the datacontainer, starts with empty hashmaps.
      */
-	public static DataContainer DC = Parser.parse("./data/TB10.gfa");
+	//public static DataContainer DC = Parser.parse("./data/TB10.gfa");
+	public static DataContainer DC = Parser.parse("../data/TB10.gfa");
 
     public DataContainer() {
         nodes= new HashMap<>();

--- a/backEnd/src/main/java/genome/Node.java
+++ b/backEnd/src/main/java/genome/Node.java
@@ -22,6 +22,8 @@ public class Node {
     private int referenceCoordinate; //coordinate of this node in the refr genome
     private int weight; // amount of genomes that contain this node
 
+    public Node(){};
+    
     public Node(int id, String sequence, String[] genomes, String referenceGenome, int referenceCoordinate) {
         this.id = id;
         this.sequence = sequence;

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/DimensionsObject.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/DimensionsObject.java
@@ -1,0 +1,38 @@
+package com.pl.tagc.tagcwebapp;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement
+public class DimensionsObject {
+
+	private double width;
+	private double height;
+
+	public DimensionsObject() {
+	}
+
+	public DimensionsObject(double width, double height) {
+		this.setWidth(width);
+		this.setHeight(height);
+	}
+
+	public double getHeight() {
+		return height;
+	}
+
+	public void setHeight(double height) {
+		this.height = height;
+	}
+
+	public double getWidth() {
+		return width;
+	}
+
+	public void setWidth(double width) {
+		this.width = width;
+	}
+
+}

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/JAXBContextResolver.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/JAXBContextResolver.java
@@ -12,7 +12,7 @@ import com.sun.jersey.api.json.JSONJAXBContext;
 public class JAXBContextResolver implements ContextResolver<JAXBContext> {
 
 	private JAXBContext context;
-	private Class[] types = { Node.class, ResultObject.class, NodeService.class };
+	private Class[] types = { Node.class, NodeListObject.class, NodeService.class };
 
 	public JAXBContextResolver() throws Exception {
 		this.context = new JSONJAXBContext(JSONConfiguration.natural().build(), types);

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/Main.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/Main.java
@@ -49,8 +49,8 @@ public class Main {
     public static void main(String[] args) throws IOException {
         // Grizzly 2 initialization
         HttpServer httpServer = startServer();
-        StaticHttpHandler staticHttpHandler = new StaticHttpHandler("tagcwebapp/static/");
-//        StaticHttpHandler staticHttpHandler = new StaticHttpHandler("static/");
+        //StaticHttpHandler staticHttpHandler = new StaticHttpHandler("tagcwebapp/static/");
+        StaticHttpHandler staticHttpHandler = new StaticHttpHandler("static/");
         staticHttpHandler.setFileCacheEnabled(false);
         httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/app");
 

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/Main.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/Main.java
@@ -11,10 +11,10 @@ import java.net.URI;
 /*
  * Instructions:
  * 
- * To use this application http://localhost:9998/getnodes?xleft=10&xright=70&ytop=30&ybtm=80 
+ * To use this application http://localhost:9998/api/getnodes?xleft=10&xright=70&ytop=30&ybtm=80 
  * can be used to get a json list of nodes that are in the viewport defined by the four 
- * values: xleft xright ytop and ybtm. http://localhost:9998/app/index.html can be used 
- * to access the static file index.html.
+ * values: xleft xright ytop and ybtm. http://localhost:9998/app/index.htm can be used 
+ * to access the static file index.htm.
  * 
  * */
 

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeListObject.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeListObject.java
@@ -1,6 +1,7 @@
 package com.pl.tagc.tagcwebapp;
 
 import genome.Node;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -10,19 +11,19 @@ import javax.xml.bind.annotation.XmlAccessorType;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement
-public class ResultObject {
+public class NodeListObject {
 	@SuppressWarnings("unused")
 	private String id = "test";
 	private List<Node> cList;
 
-	public ResultObject() {
+	public NodeListObject() {
 	}
 
-	public ResultObject(CopyOnWriteArrayList<Node> cList) {
+	public NodeListObject(CopyOnWriteArrayList<Node> cList) {
 		this.cList = cList;
 	}
 
 	public List<Node> getcList() {
 		return cList;
-	}
+	};
 }

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
@@ -21,13 +21,13 @@ public class NodeService {
 	// The Java method will produce content identified by the MIME Media
 	// type "application/json"
 	@Produces("application/json")
-	public ResultObject requestNodes(@DefaultValue("0") @QueryParam("xleft") double xLeft,
+	public NodeListObject requestNodes(@DefaultValue("0") @QueryParam("xleft") double xLeft,
 			@DefaultValue("0") @QueryParam("ytop") double yTop, @DefaultValue("100") @QueryParam("xright") double xRight,
 			@DefaultValue("100") @QueryParam("ybtm") double yBottom) {
 		return getNodes(xLeft, yTop, xRight, yBottom);
 	}
 
-	private ResultObject getNodes(double xLeft, double yTop, double xRight, double yBottom) {
+	private NodeListObject getNodes(double xLeft, double yTop, double xRight, double yBottom) {
 		CopyOnWriteArrayList<Node> res = new CopyOnWriteArrayList<Node>();
 		ArrayList<Node> correctNodes = new ArrayList<>();
 		for (Node n : cList.values()) {
@@ -43,7 +43,7 @@ public class NodeService {
 			res.add(n);
 		}
 
-		ResultObject reso = new ResultObject(res);
+		NodeListObject reso = new NodeListObject(res);
 		return reso;
 
 	}

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
@@ -10,7 +10,7 @@ import javax.ws.rs.QueryParam;
 import genome.DataContainer;
 import genome.Node;
 
-//The Java class will be hosted at the URI path "/getnodes"
+//The Java class will be hosted at the URI path "/api"
 @Path("/api")
 public class NodeService {
 	

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
@@ -10,21 +10,23 @@ import javax.ws.rs.QueryParam;
 import genome.DataContainer;
 import genome.Node;
 
-// The Java class will be hosted at the URI path "/getnodes"
-@Path("/getnodes")
+//The Java class will be hosted at the URI path "/getnodes"
+@Path("/api")
 public class NodeService {
-
+	
 	private final HashMap<Integer, Node> cList = DataContainer.DC.getNodes();
 
 	// The Java method will process HTTP GET requests
 	@GET
 	// The Java method will produce content identified by the MIME Media
 	// type "application/json"
+	@Path("/getnodes")
 	@Produces("application/json")
-	public NodeListObject requestNodes(@DefaultValue("0") @QueryParam("xleft") double xLeft,
-			@DefaultValue("0") @QueryParam("ytop") double yTop, @DefaultValue("100") @QueryParam("xright") double xRight,
-			@DefaultValue("100") @QueryParam("ybtm") double yBottom) {
-		return getNodes(xLeft, yTop, xRight, yBottom);
+	public NodeListObject requestNodes(@DefaultValue("0") @QueryParam("xleft") double xleft,
+			@DefaultValue("0") @QueryParam("ytop") double ytop, @DefaultValue("100") @QueryParam("xright") double xright,
+			@DefaultValue("100") @QueryParam("ybtm") double ybtm) {
+		NodeListObject r = getNodes(xleft, ytop, xright, ybtm);
+		return r;
 	}
 
 	// The Java method will process HTTP GET requests

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/NodeService.java
@@ -27,6 +27,16 @@ public class NodeService {
 		return getNodes(xLeft, yTop, xRight, yBottom);
 	}
 
+	// The Java method will process HTTP GET requests
+	@GET
+	// The Java method will produce content identified by the MIME Media
+	// type "application/json"
+	@Path("/getdimensions")
+	@Produces("application/json")
+	public DimensionsObject requestDimensions() {
+		return new DimensionsObject(DataContainer.DC.getDataWidth(), DataContainer.DC.getDataHeight());
+	}
+
 	private NodeListObject getNodes(double xLeft, double yTop, double xRight, double yBottom) {
 		CopyOnWriteArrayList<Node> res = new CopyOnWriteArrayList<Node>();
 		ArrayList<Node> correctNodes = new ArrayList<>();

--- a/tagcwebapp/static/js/main.js
+++ b/tagcwebapp/static/js/main.js
@@ -2,7 +2,7 @@
 var animationSpeed = 1000;
 var currentHover = null;
 var zoomTimeout = null;
-var url = 'http://localhost:9998/app/';
+var url = 'http://localhost:9998/';
 var ratio = 0;
 var minHeight = 300;
 var yZoom = 1;
@@ -166,7 +166,7 @@ function computeBoundingBox(x, y, width, height)
 
 function getNodes(boundingBox, callback) {
     $.ajax({
-        url: url + '../getnodes',
+        url: url + 'api/getnodes',
         dataType: 'JSON',
         type: 'GET',
         data: boundingBox
@@ -182,7 +182,7 @@ function initialize() {
 
 function initializeMinimap() {
     $.ajax({
-        url: url + 'getdimensions',
+        url: url + 'api/getdimensions',
         dataType: 'JSON',
         type: 'GET'
     }).done(function(data) {


### PR DESCRIPTION
I have connected the frontend to the backend by making a static DataContainer field in the DataContainer class so the REST services can easily access the backend data. I don't think that this is good practice. However this is based on Oracle's example code in which they show how to use Jersey which is their JAX-RS reference implementation that we are using. I have also improved the REST api. From now on any api calls will be made to \<host address\>/api/\<call\>. Current calls that can be made are getnodes and getdimensions.