### PR TITLE
fixed multiple selection and 500 error bug solved

### DIFF
--- a/backEnd/src/main/java/datatree/DataTree.java
+++ b/backEnd/src/main/java/datatree/DataTree.java
@@ -98,6 +98,7 @@ public class DataTree extends TreeStructure<DataNode> {
             }
         }
 
+
         for (DataNode node : nodes) {
             for (Strand strand : node.getStrands()) {
                 if (strand.getSequence().length() > minSize) {
@@ -165,13 +166,11 @@ public class DataTree extends TreeStructure<DataNode> {
         for (Genome g : genome) {
             ids.add(g.getId());
         }
+
         Set<DataNode> result = new HashSet<>();
         DataNode currentNode = getRoot();
-        int totalStrands = 0;
         while (currentNode.getLevel() <= level) {
             result.add(currentNode);
-            totalStrands += currentNode.getStrands().size();
-
             currentNode = currentNode.getChildWithGenome(ids);
             if (currentNode == null) {
                 break;

--- a/backEnd/src/main/java/genome/Genome.java
+++ b/backEnd/src/main/java/genome/Genome.java
@@ -4,7 +4,6 @@ import metadata.GenomeMetadata;
 
 import java.util.ArrayList;
 
-// TODO: Auto-generated Javadoc
 
 /**
  * The Class Genome.

--- a/backEnd/src/main/java/genome/GenomeGraph.java
+++ b/backEnd/src/main/java/genome/GenomeGraph.java
@@ -111,27 +111,30 @@ public class GenomeGraph {
         List<String> unrecognizedGenomes = new ArrayList<String>();
         this.activeGenomes = new ArrayList<>();
         this.activeGenomeIds = new ArrayList<>();
-
-        for (ArrayList<String> genomeIds : ids) {
-            ArrayList<Genome> input = new ArrayList<>();
-            for (String genomeId : genomeIds) {
-                Genome genome = genomes.get(genomeId);
-                if (genome != null) {
-                    input.add(genome);
-                    if (!activeGenomeIds.contains(genome.getId())) {
-                        activeGenomeIds.add(genome.getId());
+        if (ids != null) {
+            for (ArrayList<String> genomeIds : ids) {
+                ArrayList<Genome> input = new ArrayList<>();
+                for (String genomeId : genomeIds) {
+                    Genome genome = genomes.get(genomeId);
+                    if (genome != null) {
+                        input.add(genome);
+                        genome.resetStrandX();
+                        if (!activeGenomeIds.contains(genome.getId())) {
+                            activeGenomeIds.add(genome.getId());
+                        }
+                    } else {
+                        unrecognizedGenomes.add(genomeId);
                     }
-                } else {
-                    unrecognizedGenomes.add(genomeId);
+                }
+                if (input.size() > 0) {
+                    activeGenomes.add(input);
                 }
             }
-            if (input.size() > 0) {
-                activeGenomes.add(input);
+            for (ArrayList<Genome> genome : activeGenomes) {
+                genome.get(0).setStrandsX();
             }
         }
-        for (ArrayList<Genome> genome : activeGenomes) {
-            genome.get(0).setStrandsX();
-        }
+        System.out.println("New genomes to compare: " + activeGenomeIds.toString());
         return unrecognizedGenomes;
     }
 

--- a/backEnd/src/main/java/ribbonnodes/RibbonNodeFactory.java
+++ b/backEnd/src/main/java/ribbonnodes/RibbonNodeFactory.java
@@ -24,7 +24,7 @@ public abstract class RibbonNodeFactory {
                                                       Strand strand,
                                                       ArrayList<String> activeGenomes) {
 
-        HashSet<String> actGen = strand.getGenomes();
+        HashSet<String> actGen = (HashSet<String>) strand.getGenomes().clone();
         actGen.retainAll(activeGenomes);
         RibbonNode ribbon = new RibbonNode(id, actGen);
         ribbon.setX(strand.getX());

--- a/backEnd/src/test/java/genome/GenomeGraphTest.java
+++ b/backEnd/src/test/java/genome/GenomeGraphTest.java
@@ -80,5 +80,6 @@ public class GenomeGraphTest {
         assertEquals(data.getActiveGenomes().get(0).get(0).getId(), "ref1");
         assertEquals(notPresent.size(), 1);
         assertEquals(notPresent.get(0), "ref2");
+        data.setGenomesAsActive(null);
     }
 }

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/AdaptedPhylogeneticNode.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/AdaptedPhylogeneticNode.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
  * The Class AdaptedPhylogeneticNode.
  */
 @XmlType(propOrder = {"nameLabel", "originalChildOrder",
-        "children", "distance", "annotation", "id"})
+        "children", "annotation", "id"})
 public class AdaptedPhylogeneticNode {
 
     /**

--- a/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/BackEndAdapter.java
+++ b/tagcwebapp/src/main/java/com/pl/tagc/tagcwebapp/BackEndAdapter.java
@@ -6,6 +6,7 @@ import genome.GraphSearcher.SearchType;
 
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/tagcwebapp/src/main/resources/static/index.htm
+++ b/tagcwebapp/src/main/resources/static/index.htm
@@ -86,7 +86,7 @@
             <button id="expandPhyloView" type="button"
                     class="btn btn-default" data-dismiss="modal">+</button>
             <ul id="phyloColorLegenda"></ul>
-            <div class="right">ZoomLevel<input type="number" id="phyloZoomLevel" value="6"></div>
+            <div class="right">ZoomLevel<input type="number" min="1" id="phyloZoomLevel" value="6"></div>
           </div>
         </div>
         <ul id="selectedGenomeList">


### PR DESCRIPTION
The strand genomes removed all except the previously selected, resulting in an edge draw problem in the frontend. Also, the new selected genomes did not reset their x. The 500 error was caused by an xmlannotation that was dead. all is resolved now.